### PR TITLE
Fix issue with initial tpf value

### DIFF
--- a/src/main/java/com/simsilica/sim/GameSystemManager.java
+++ b/src/main/java/com/simsilica/sim/GameSystemManager.java
@@ -173,9 +173,11 @@ public class GameSystemManager {
             sys.start();
         }
         state = State.Started;
-        // Update the step time...
+     
+        // Initialize the starting time value
         long time = System.nanoTime(); 
         stepTime.update(time);
+     
         EventBus.publish(SimEvent.simStarted, simEvent);
     }
  

--- a/src/main/java/com/simsilica/sim/GameSystemManager.java
+++ b/src/main/java/com/simsilica/sim/GameSystemManager.java
@@ -173,6 +173,9 @@ public class GameSystemManager {
             sys.start();
         }
         state = State.Started;
+        // Update the step time...
+        long time = System.nanoTime(); 
+        stepTime.update(time);
         EventBus.publish(SimEvent.simStarted, simEvent);
     }
  


### PR DESCRIPTION
The ‘start time’ that is used for the delta is initialized to 0 so the first frame that gets an update of the current nanoTime will be pretty huge.
This commit updates the time to current nanoTime during system manager start phase.