### PR TITLE
Proper release the entity set in EntityContainer.stop()

### DIFF
--- a/src/main/java/com/simsilica/es/EntityContainer.java
+++ b/src/main/java/com/simsilica/es/EntityContainer.java
@@ -215,6 +215,7 @@ public abstract class EntityContainer<T> {
     public void stop() {
         removeObjects(entities);
         this.entities.release();
+        this.entities = null;
     }
     
     @Override


### PR DESCRIPTION
this will fix an issue with resetting filter when EntityContainer is stopped.